### PR TITLE
D1 wip python fix

### DIFF
--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
+++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
 		buff = PyByteArray_FromStringAndSize(
 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
+		resultobj = SWIG_AppendOutput(resultobj, buff);
 	}
 }
 
@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
 
 %typemap(argout) int *depth {
         PyObject *val = Py_BuildValue("i", *arg$argnum);
-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
+        resultobj = SWIG_AppendOutput(resultobj, val);
 }
 
 %apply int *depth { int *depth };
@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
            if (PyTuple_GET_SIZE(resultobj) == 0)
               resultobj = val;
            else
-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
+              resultobj = SWIG_AppendOutput(resultobj, val);
         }
 }
 


### PR DESCRIPTION
**Context**
The HEAD of the `d1-wip` branch of this repo, commit 2e89b706f5c956a70c989cd31665f1429e9a0b48, is used in The Yocto Project's meta-riscv layer for all D1 based boards.

On the current master branch for the upcoming Walnascar 5.2 release, u-boot doesn't build anymore due to an update in the Python versions.

**Fix**
This is a backport of an upstream u-boot patch required to build this branch with a current python version.

This is back compatible and still works with previous python versions.
