### PR TITLE
sunxi: d1:  board: sunxi: fdt fixup of dram size for d1 platforms

### DIFF
--- a/board/sunxi/Kconfig
+++ b/board/sunxi/Kconfig
@@ -105,8 +105,9 @@ config SUNXI_GEN_NCAT2
 
 config SUNXI_MINIMUM_DRAM_MB
 	int
-	default 32 if MACH_SUNIV
-	default 64 if MACH_SUN8I_V3S || TARGET_SUN20I_D1
+	default 32  if MACH_SUNIV
+	default 64  if MACH_SUN8I_V3S
+	default 512 if TARGET_SUN20I_D1
 	default 256
 	help
 	  Minimum DRAM size expected on the board. Traditionally we

--- a/board/sunxi/board-riscv.c
+++ b/board/sunxi/board-riscv.c
@@ -617,6 +617,14 @@ int ft_board_setup(void *blob, struct bd_info *bd)
 	if (r)
 		return r;
 #endif
+
+#ifdef CONFIG_TARGET_SUN20I_D1
+	r = fdt_fixup_memory(blob, (u64)gd->ram_base, (u64)gd->ram_size);
+	if (r)
+		printf("WARNING: DRAM fdt_fixup failed\n");
+
+#endif
+
 	return 0;
 }
 

--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -118,6 +118,20 @@
 #define FDTOVERLAY_ADDR_R __stringify(SDRAM_OFFSET(FE00000))
 #define RAMDISK_ADDR_R    __stringify(SDRAM_OFFSET(FF00000))
 
+#elif (CONFIG_SUNXI_MINIMUM_DRAM_MB >= 512)
+/*
+ * 416 RAM (512M minimum minus 64MB heap + 32MB for u-boot, stack, fb, etc.
+ * 64M uncompressed kernel, 1M fdt,
+ * 1M script, 1M pxe, 1M dt overlay and the ramdisk at the end.
+ */
+#define BOOTM_SIZE        __stringify(0xa000000)
+#define KERNEL_ADDR_R     __stringify(SDRAM_OFFSET(2000000))
+#define FDT_ADDR_R        __stringify(SDRAM_OFFSET(6000000))
+#define SCRIPT_ADDR_R     __stringify(SDRAM_OFFSET(6100000))
+#define PXEFILE_ADDR_R    __stringify(SDRAM_OFFSET(6200000))
+#define FDTOVERLAY_ADDR_R __stringify(SDRAM_OFFSET(6300000))
+#define RAMDISK_ADDR_R    __stringify(SDRAM_OFFSET(6400000))
+
 #elif (CONFIG_SUNXI_MINIMUM_DRAM_MB >= 256)
 /*
  * 160M RAM (256M minimum minus 64MB heap + 32MB for u-boot, stack, fb, etc.


### PR DESCRIPTION
Hi @smaeul 

While adding support for this board in Buildroot, I discovered that I couldn't simply switch to using the mainline Linux DTS.
This merge request includes two patches that enable its use without further modifications. In brief:
* the first commit patches dtb for Linux with DRAM information obtained by SPL
* the second commit tunes load addresses in U-Boot default environment in order to add support for larger Linux images

Please let me know if I got it wrong and there is a proper default way to handle this.

Regards,
Sergey
